### PR TITLE
Fix practice typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ✈️ Travel-Bot — AI-Powered Itinerary Planner
 
 A conversational web app that turns **any travel question** into a clickable, hour-by-hour plan.  
-Built to **learn React from scratch**, practise modern tooling, and explore LLM+API orchestration.
+Built to **learn React from scratch**, practice modern tooling, and explore LLM+API orchestration.
 
 ---
 


### PR DESCRIPTION
## Summary
- correct 'practice' typo on line 4 of README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683ff6e3567c832ab8f009d578f4923a