### PR TITLE
Update proxy settings

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,9 +8,8 @@ export default defineConfig({
     proxy: {
       // if your Express route is app.post('/chat', …)
       '/api': {
-        target: 'http://localhost:3000',   // ← use your server port
+        target: 'http://localhost:8787',   // ← use your server port
         changeOrigin: true,
-        rewrite: (path) => path.replace(/^\/api/, ''),  
         secure: false,
       },
     },


### PR DESCRIPTION
## Summary
- point Vite proxy to `http://localhost:8787`
- keep `/api` prefix by removing the rewrite option

## Testing
- `npm run build`
- `npm run dev`