### PR TITLE
Add remember me persistence

### DIFF
--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,6 +1,11 @@
 import { useState } from 'react';
 import { useNavigate, Link } from 'react-router-dom';
-import { signInWithEmailAndPassword } from 'firebase/auth';
+import {
+  signInWithEmailAndPassword,
+  setPersistence,
+  browserLocalPersistence,
+  browserSessionPersistence
+} from 'firebase/auth';
 import { auth } from '../lib/firebase';
 import AuthLayout from './AuthLayout';
 import GoogleBtn from '../components/GoogleBtn';
@@ -10,11 +15,16 @@ export default function Login() {
   const nav = useNavigate();
   const [email, setEmail] = useState('');
   const [pwd, setPwd] = useState('');
+  const [remember, setRemember] = useState(false);
   const [err, setErr] = useState<string | null>(null);
 
   async function submit(e: React.FormEvent) {
     e.preventDefault();
     try {
+      await setPersistence(
+        auth,
+        remember ? browserLocalPersistence : browserSessionPersistence
+      );
       await signInWithEmailAndPassword(auth, email, pwd);
       nav('/chat', { replace: true });
     } catch (e: any) {
@@ -41,6 +51,29 @@ export default function Login() {
           onChange={e => setPwd(e.target.value)}
           required
         />
+        <label className="flex items-center justify-between text-white/80">
+          <span className="text-sm select-none">Remember me</span>
+          <span className="relative inline-block w-10" >
+            <input
+              type="checkbox"
+              checked={remember}
+              onChange={e => setRemember(e.target.checked)}
+              className="sr-only peer"
+            />
+            <div
+              className="
+                block w-10 h-6 rounded-full bg-white/30
+                peer-checked:bg-indigo-600 transition-colors
+              "
+            ></div>
+            <div
+              className="
+                absolute top-0 left-0 h-6 w-6 bg-white rounded-full shadow
+                transform peer-checked:translate-x-4 transition-transform
+              "
+            ></div>
+          </span>
+        </label>
         <button
           className="
             w-full rounded-lg bg-indigo-600


### PR DESCRIPTION
## Summary
- add remember me toggle on Login page
- persist user session to local or session storage based on toggle

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68400b3fb0f4832abc37691803afb0af