### PR TITLE
Add noproxy script for dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,7 @@ cp .env.example .env
 
 # 4. Run dev servers (Vite + Express proxy)
 npm run dev
+
+# If you see "http proxy error" messages, your environment
+# might have HTTP(S)_PROXY variables set. Disable them with:
+#   npm run dev:noproxy

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "concurrently \"vite\" \"TS_NODE_TRANSPILE_ONLY=true TS_NODE_PROJECT=tsconfig.node.json nodemon --loader ts-node/esm server.mjs\"",
+    "dev:noproxy": "node ./scripts/no-proxy.js",
     "build": "vite build",
     "preview": "vite preview"
   },

--- a/scripts/no-proxy.js
+++ b/scripts/no-proxy.js
@@ -1,0 +1,17 @@
+import { spawn } from 'child_process';
+
+const proxyVars = [
+  'http_proxy',
+  'https_proxy',
+  'HTTP_PROXY',
+  'HTTPS_PROXY',
+  'npm_config_http_proxy',
+  'npm_config_https_proxy'
+];
+
+for (const v of proxyVars) {
+  delete process.env[v];
+}
+
+spawn('npm', ['run', 'dev'], { stdio: 'inherit', shell: true });
+


### PR DESCRIPTION
## Summary
- add script to remove HTTP proxy env vars before starting dev server
- document new npm run dev:noproxy command in README

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*
