### PR TITLE
Add generic result cards

### DIFF
--- a/architecture.txt
+++ b/architecture.txt
@@ -18,10 +18,11 @@ travel-bot/
     │
     ├── components/               # UI atoms (stateless)
     │   ├── BackgroundGrid.tsx    # CSS grid + parallax
-    │   ├── ChatWindow.tsx        # message list
     │   ├── GoogleBtn.tsx         # OAuth button (custom SVG)
-    │   ├── InputBar.tsx          # textarea + send
-    │   └── TextInput.tsx         # glassy input field
+    │   ├── ResultCard.tsx        # card for flights or attractions
+    │   ├── TextInput.tsx         # glassy input field
+    │   └── TravelChatUI.tsx      # chat UI; parses assistant replies to render ResultCard
+    │                             # detects JSON blocks or enumerated lists
     │
     ├── contexts/
     │   └── AuthContext.tsx       # Firebase user provider
@@ -38,7 +39,7 @@ travel-bot/
     │   └── SignUp.tsx            # create account
     │
     ├── store/                    # global state (Zustand)
-    │   └── useChats.tsx          # messages array + send()
+    │   └── useChat.ts            # messages array + send()
     │
     ├── types/
     │   └── vanta-waves.d.ts      # TS stub for Vanta import

--- a/src/components/ResultCard.tsx
+++ b/src/components/ResultCard.tsx
@@ -1,37 +1,48 @@
-interface FlightProps {
-    price: number;
-    airline: string;
+import React from 'react';
+
+export type FlightResult = {
+  kind: 'flight';
+  price: number;
+  airline: string;
+  departureTime: string;
+  arrivalTime: string;
+  duration: string;
+  stops: number;
+  bookingLink?: string;
+  returnInfo?: {
     departureTime: string;
     arrivalTime: string;
     duration: string;
     stops: number;
-    bookingLink: string;
-    returnInfo?: {
-      departureTime: string;
-      arrivalTime: string;
-      duration: string;
-      stops: number;
-    };
-  }
-  
-  export default function FlightCard({ 
-    price, 
-    airline, 
-    departureTime, 
-    arrivalTime, 
-    duration, 
-    stops, 
-    bookingLink,
-    returnInfo
-  }: FlightProps) {
+  };
+};
+
+export type PoiResult = {
+  kind: 'poi';
+  name: string;
+  category?: string;
+  link: string;
+};
+
+export type Result = FlightResult | PoiResult;
+
+interface Props {
+  result: Result;
+}
+
+export default function ResultCard({ result }: Props) {
+  if (result.kind === 'flight') {
+    const { price, airline, departureTime, arrivalTime, duration, stops, bookingLink, returnInfo } = result;
     const stopsText = stops === 0 ? 'Nonstop' : `${stops} stop${stops > 1 ? 's' : ''}`;
-    
+
     const handleClick = () => {
-      window.open(bookingLink, '_blank');
+      if (bookingLink) {
+        window.open(bookingLink, '_blank');
+      }
     };
-  
+
     return (
-      <div 
+      <div
         className="bg-white border border-gray-200 rounded-lg p-4 mb-4 shadow-sm hover:shadow-md transition-shadow cursor-pointer"
         onClick={handleClick}
       >
@@ -39,7 +50,7 @@ interface FlightProps {
           <div className="font-medium text-lg">{airline}</div>
           <div className="text-xl font-bold text-blue-600">${price}</div>
         </div>
-        
+
         <div className="mb-2">
           <div className="flex justify-between mb-1">
             <div className="font-medium">{departureTime}</div>
@@ -51,7 +62,7 @@ interface FlightProps {
             <div>{stopsText}</div>
           </div>
         </div>
-        
+
         {returnInfo && (
           <div className="mt-3 pt-3 border-t border-gray-200">
             <div className="text-sm text-gray-500 mb-1">Return</div>
@@ -66,10 +77,39 @@ interface FlightProps {
             </div>
           </div>
         )}
-        
-        <div className="mt-3 text-center">
-          <button className="text-sm text-blue-600 hover:underline">Book this flight</button>
-        </div>
+
+        {bookingLink && (
+          <div className="mt-3 text-center">
+            <button className="text-sm text-blue-600 hover:underline" onClick={handleClick}>
+              Book now
+            </button>
+          </div>
+        )}
       </div>
     );
   }
+
+  // POI
+  const { name, category, link } = result;
+
+  const handleClick = () => {
+    window.open(link, '_blank');
+  };
+
+  return (
+    <div
+      className="bg-white border border-gray-200 rounded-lg p-4 mb-4 shadow-sm hover:shadow-md transition-shadow cursor-pointer"
+      onClick={handleClick}
+    >
+      <div className="flex justify-between items-start">
+        <div>
+          <div className="font-medium text-lg">{name}</div>
+          {category && <div className="text-sm text-gray-500">{category}</div>}
+        </div>
+        <button className="text-sm text-blue-600 hover:underline" onClick={handleClick}>
+          Directions
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/TravelChatUI.tsx
+++ b/src/components/TravelChatUI.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef, FC } from 'react';
 import { SendHorizontal, Loader2, Plus, Trash2 } from 'lucide-react';
 import { useChatStore } from '../store/useChat';    // ← corrected hook path
-import FlightCard from './FlightCard';
+import ResultCard, { FlightResult, PoiResult, Result } from './ResultCard';
 
 // Sample travel prompts for initial screen
 const SAMPLE_PROMPTS = [
@@ -66,75 +66,91 @@ export default function TravelChatUI() {
     setInput(prompt);
   };
 
-  // Parse assistant message for flights
-  interface Flight {
-    price: number;
-    airline: string;
-    departureTime: string;
-    arrivalTime: string;
-    duration: string;
-    stops: number;
-    bookingLink: string;
-    returnInfo?: {
-      departureTime: string;
-      arrivalTime: string;
-      duration: string;
-      stops: number;
-    };
-  }
-
-  const processMessage = (msg: { role: string; content: string }) => {
+  // Parse assistant messages for structured results
+  const processMessage = (msg: { role: string; content: string }): { content: string; results?: Result[] } => {
     if (msg.role !== 'assistant') return { content: msg.content };
 
-    if (!msg.content.includes('[Book flight](')) return { content: msg.content };
-
-    const flights: Flight[] = [];
-    const blocks = msg.content.split(/\n\n/).filter(b => b.includes('[Book flight]('));
-    for (const block of blocks) {
+    // ----- JSON block -----
+    const jsonMatch = msg.content.match(/```json\n([\s\S]+?)\n```/i);
+    if (jsonMatch) {
       try {
-        const priceMatch = block.match(/\*\*\$(\d+(?:\.\d+)?)\*\*/);
-        const airlineMatch = block.match(/\*\*\$\d+(?:\.\d+)?\*\* - ([^\n]+)/);
-        const outboundMatch = block.match(/• Outbound: ([^(]+)/);
-        const linkMatch = block.match(/\[Book flight\]\(([^)]+)\)/);
-        if (!priceMatch || !airlineMatch || !outboundMatch || !linkMatch) continue;
-
-        const [dep, arr] = outboundMatch[1].split(' → ');
-        const durationMatch = block.match(/\(([^,]+),/);
-        const stopsMatch = block.match(/(Nonstop|\d+ stop(?:s)?)/);
-
-        const flight: Flight = {
-          price: parseFloat(priceMatch[1]),
-          airline: airlineMatch[1].trim(),
-          departureTime: dep.trim(),
-          arrivalTime: arr.trim(),
-          duration: durationMatch ? durationMatch[1].trim() : 'N/A',
-          stops: stopsMatch ? (stopsMatch[1] === 'Nonstop' ? 0 : parseInt(stopsMatch[1])) : 0,
-          bookingLink: linkMatch[1]
-        };
-
-        const returnMatch = block.match(/• Return: ([^(]+)/);
-        if (returnMatch) {
-          const [rd, ra] = returnMatch[1].split(' → ');
-          const allDur = [...block.matchAll(/\(([^,]+),/g)];
-          const allStops = [...block.matchAll(/(Nonstop|\d+ stop(?:s)?)/g)];
-          if (allDur.length > 1 && allStops.length > 1) {
-            flight.returnInfo = {
-              departureTime: rd.trim(),
-              arrivalTime: ra.trim(),
-              duration: allDur[1][1].trim(),
-              stops: allStops[1][1] === 'Nonstop' ? 0 : parseInt(allStops[1][1])
-            };
+        const data = JSON.parse(jsonMatch[1]);
+        const results: Result[] = [];
+        if (Array.isArray(data.flights)) {
+          for (const f of data.flights) {
+            results.push({
+              kind: 'flight',
+              price: f.price,
+              airline: f.airline,
+              departureTime: f.departureTime,
+              arrivalTime: f.arrivalTime,
+              duration: f.duration || 'N/A',
+              stops: f.stops ?? 0,
+              bookingLink: f.bookingLink,
+              returnInfo: f.returnInfo
+            });
           }
         }
-
-        flights.push(flight);
+        if (Array.isArray(data.pois)) {
+          for (const p of data.pois) {
+            results.push({
+              kind: 'poi',
+              name: p.name,
+              link: p.link,
+              category: p.category
+            });
+          }
+        }
+        if (results.length) {
+          const content = msg.content.replace(jsonMatch[0], '').trim();
+          return { content, results };
+        }
       } catch (e) {
-        console.error('parse error', e);
+        console.error('JSON parse error', e);
       }
     }
 
-    if (flights.length) {
-      return { content: 'Certainly! Here are a few flights I found:', flights };
+    // ----- Flights -----
+    const flightLines = msg.content
+      .split(/\n/)
+      .filter((l) => /^\d+\./.test(l) && /Airline/i.test(l));
+    if (flightLines.length) {
+      const flights: FlightResult[] = [];
+      for (const line of flightLines) {
+        const m = line.match(/Airline\s+([^,]+),\s*Departure:\s*([^,]+),\s*Arrival:\s*([^,]+),\s*Stops:\s*([^,]+),\s*Price:\s*\$(\d+(?:\.\d+)?)/i);
+        if (!m) continue;
+        flights.push({
+          kind: 'flight',
+          airline: m[1].trim(),
+          departureTime: m[2].trim(),
+          arrivalTime: m[3].trim(),
+          duration: 'N/A',
+          stops: m[4].toLowerCase().includes('nonstop') ? 0 : parseInt(m[4], 10),
+          price: parseFloat(m[5]),
+          bookingLink: ''
+        });
+      }
+      if (flights.length) {
+        const remaining = msg.content
+          .split('\n')
+          .filter((l) => !flightLines.includes(l))
+          .join('\n')
+          .trim();
+        return { content: remaining || 'Certainly! Here are a few flights I found:', results: flights };
+      }
+    }
+
+    // ----- Points of interest -----
+    const poiMatches = [...msg.content.matchAll(/\d+\.\s+\[([^\]]+)\]\(([^)]+)\)(?:\s*-\s*([^\n]+))?/g)];
+    if (poiMatches.length) {
+      const pois: PoiResult[] = poiMatches.map((m) => ({
+        kind: 'poi',
+        name: m[1],
+        link: m[2],
+        category: m[3]?.trim()
+      }));
+      const remaining = msg.content.replace(/\d+\.\s+\[[^\]]+\]\([^\)]+\)(?:\s*-\s*[^\n]+)?\n?/g, '').trim();
+      return { content: remaining || 'Certainly! Here are some attractions:', results: pois };
     }
 
     return { content: msg.content };
@@ -193,7 +209,7 @@ export default function TravelChatUI() {
         ) : (
           <>
             {messages.map((msg, i) => {
-              const { content, flights } = processMessage(msg);
+              const { content, results } = processMessage(msg);
               return (
                 <div
                   key={i}
@@ -213,18 +229,8 @@ export default function TravelChatUI() {
                     ) : (
                       <div>{content}</div>
                     )}
-                    {flights?.map((f, idx) => (
-                      <FlightCard
-                        key={idx}
-                        price={f.price}
-                        airline={f.airline}
-                        departureTime={f.departureTime}
-                        arrivalTime={f.arrivalTime}
-                        duration={f.duration}
-                        stops={f.stops}
-                        bookingLink={f.bookingLink}
-                        returnInfo={f.returnInfo}
-                      />
+                    {results?.map((r, idx) => (
+                      <ResultCard key={idx} result={r} />
                     ))}
                   </div>
                 </div>


### PR DESCRIPTION
## Summary
- create `ResultCard` component to display flights and POIs
- parse assistant messages for flights or POIs in `TravelChatUI`
- remove parsed lines from the chat log for cleaner display

## Testing
- `npm run build`
- `npm run dev` *(checked startup)*

------
https://chatgpt.com/codex/tasks/task_e_6841409c0f80832aa0258ed1f19bae5b