### PR TITLE
Fix proxy connection error in dev setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,5 @@ cp .env.example .env
 # → add Firebase + Gemini + OpenTripMap keys
 
 # 4. Run dev servers (Vite + Express proxy)
+# (The script will automatically ignore HTTP proxy variables)
 npm run dev
-
-# If you see "http proxy error" messages, your environment
-# might have HTTP(S)_PROXY variables set. Disable them with:
-#   npm run dev:noproxy

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "concurrently \"vite\" \"TS_NODE_TRANSPILE_ONLY=true TS_NODE_PROJECT=tsconfig.node.json nodemon --loader ts-node/esm server.mjs\"",
-    "dev:noproxy": "node ./scripts/no-proxy.js",
+    "dev": "node ./scripts/dev.js",
+    "dev:noproxy": "node ./scripts/dev.js",
     "build": "vite build",
     "preview": "vite preview"
   },

--- a/scripts/dev.js
+++ b/scripts/dev.js
@@ -1,0 +1,27 @@
+import { spawn } from 'child_process';
+
+const proxyVars = [
+  'http_proxy',
+  'https_proxy',
+  'HTTP_PROXY',
+  'HTTPS_PROXY',
+  'npm_config_http_proxy',
+  'npm_config_https_proxy'
+];
+
+let cleaned = false;
+for (const v of proxyVars) {
+  if (process.env[v]) {
+    delete process.env[v];
+    cleaned = true;
+  }
+}
+
+if (cleaned) {
+  console.log('[dev] Removed HTTP proxy environment variables to avoid connection errors.');
+}
+
+spawn('npx', ['concurrently',
+  '"vite"',
+  '"TS_NODE_TRANSPILE_ONLY=true TS_NODE_PROJECT=tsconfig.node.json nodemon --loader ts-node/esm server.mjs"'
+], { stdio: 'inherit', shell: true });


### PR DESCRIPTION
## Summary
- add `scripts/dev.js` to strip proxy variables before launching dev servers
- run `scripts/dev.js` from npm scripts
- update docs to note automatic proxy cleanup

## Testing
- `npm run dev`