### PR TITLE
Fix dev server on Windows

### DIFF
--- a/scripts/dev.js
+++ b/scripts/dev.js
@@ -1,4 +1,4 @@
-import { spawn } from 'child_process';
+import { concurrently } from 'concurrently';
 
 const proxyVars = [
   'http_proxy',
@@ -21,7 +21,18 @@ if (cleaned) {
   console.log('[dev] Removed HTTP proxy environment variables to avoid connection errors.');
 }
 
-spawn('npx', ['concurrently',
-  '"vite"',
-  '"TS_NODE_TRANSPILE_ONLY=true TS_NODE_PROJECT=tsconfig.node.json nodemon --loader ts-node/esm server.mjs"'
-], { stdio: 'inherit', shell: true });
+const commands = [
+  { command: 'vite', name: 'vite', prefixColor: 'cyan' },
+  {
+    command: 'nodemon --loader ts-node/esm server.mjs',
+    name: 'server',
+    prefixColor: 'gray',
+    env: {
+      TS_NODE_TRANSPILE_ONLY: 'true',
+      TS_NODE_PROJECT: 'tsconfig.node.json'
+    }
+  }
+];
+
+const { result } = concurrently(commands, { prefix: 'name' });
+result.catch(() => process.exit(1));


### PR DESCRIPTION
## Summary
- update `scripts/dev.js` to spawn `vite` and `nodemon` programmatically
- ensure required environment variables are passed when spawning `nodemon`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68896513ce7c832aa23e9c4129069f36